### PR TITLE
Fixed deprecated use of "consumedMore" instead of "spentGold" in

### DIFF
--- a/AndorsTrail/res/raw/conversationlist_debug.json
+++ b/AndorsTrail/res/raw/conversationlist_debug.json
@@ -144,7 +144,7 @@
       {
         "requires": [
           {
-            "requireType": "consumedMore",
+            "requireType": "spentGold",
             "requireID": "gold",
             "value": 100
           }


### PR DESCRIPTION
conversationlist_debug.json
Thanks to Moerit for helping spotting it.
