### PR TITLE
Bugfix dualwield hp crit boosts

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/SkillController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/SkillController.java
@@ -351,9 +351,10 @@ public final class SkillController {
 				addPercentMaxHPBoost(player, offHandItem, percent, 100);
 				addPercentDamageResistance(player, offHandItem, percent, 100);
 				addPercentMaxAPBoost(player, offHandItem, percent, 100);
-				addPercentMoveCost(player, offHandItem, percent, 100);
-				addPercentReequipCost(player, offHandItem, percent, 100);
-				addPercentUseItemCost(player, offHandItem, percent, 100);
+				//Reversed parameters, as a positive value is a malus for these...
+				addPercentMoveCost(player, offHandItem, 100, percent);
+				addPercentReequipCost(player, offHandItem, 100, percent);
+				addPercentUseItemCost(player, offHandItem, 100, percent);
 				
 			}
 


### PR DESCRIPTION
Fixed bug referenced in this forum topic : http://andorstrail.com/viewtopic.php?f=3&t=4555

HP part discussed in last team meeting.
Crit part can be discussed, to adapt behavior. I just sticked by the skill description, but my interpretation may be wrong.
